### PR TITLE
Clear old state on mode transition between Local/Proxy/NoCache

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -619,10 +619,9 @@ type Proxy struct {
 	// CA specifies the path to the custom CA file for the remote registry (RemoteURL)
 	CA *string `yaml:"ca,omitempty"`
 
-	// TTL is the expiry time of the content and will be cleaned up when it expires
-	// if not set, defaults to 7 * 24 hours
-	// If set to zero, will never expire cache
-	TTL *time.Duration `yaml:"ttl,omitempty"`
+	// TTL is the expiry time of the content and will be cleaned up when it expires.
+	// If not set or less than 0, defaults to 7 days (7 * 24 hours)
+	TTL time.Duration `yaml:"ttl,omitempty"`
 
 	// NoCache explicitly disables the cache for this proxy.
 	NoCache bool `yaml:"nocache,omitempty"`

--- a/registry/handlers/api_test.go
+++ b/registry/handlers/api_test.go
@@ -885,7 +885,7 @@ func testBlobDelete(t *testing.T, env *testEnv, args blobArgs) {
 	ref, _ := reference.WithDigest(imageName, layerDigest)
 	layerURL, err := env.builder.BuildBlobURL(ref)
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 	// ---------------
 	// Delete a layer
@@ -1131,6 +1131,10 @@ func (dr *mockErrorDriver) GetContent(ctx context.Context, path string) ([]byte,
 		}
 	}
 	return nil, errors.New("Unknown storage error")
+}
+
+func (dr *mockErrorDriver) Stat(ctx context.Context, path string) (storagedriver.FileInfo, error) {
+	return nil, storagedriver.PathNotFoundError{Path: path}
 }
 
 func TestGetManifestWithStorageError(t *testing.T) {

--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -33,7 +33,6 @@ import (
 	"github.com/docker/distribution/registry/storage"
 	memorycache "github.com/docker/distribution/registry/storage/cache/memory"
 	rediscache "github.com/docker/distribution/registry/storage/cache/redis"
-	"github.com/docker/distribution/registry/storage/driver"
 	storagedriver "github.com/docker/distribution/registry/storage/driver"
 	"github.com/docker/distribution/registry/storage/driver/factory"
 	storagemiddleware "github.com/docker/distribution/registry/storage/driver/middleware"
@@ -318,29 +317,19 @@ func NewApp(ctx context.Context, config *configuration.Configuration) *App {
 		dcontext.GetLogger(app).Debugf("configured %q access controller", authType)
 	}
 
-	// configure as a pull through cache
-	if config.Proxy.RemoteURL == "" || (config.Proxy.TTL != nil && *config.Proxy.TTL <= 0) || config.Proxy.NoCache {
-		// Remove "/scheduler-state.json"
-		pathToStateFile := "/scheduler-state.json"
-		if _, err := app.driver.Stat(ctx, pathToStateFile); err != nil {
-			switch err := err.(type) {
-			case driver.PathNotFoundError:
-			default:
-				panic(err.Error())
-			}
-		} else {
-			if err := app.driver.Delete(ctx, pathToStateFile); err != nil {
-				panic(err.Error())
-			}
-		}
-	}
 	if config.Proxy.RemoteURL != "" {
+		// Run proxy
 		app.registry, err = proxy.NewRegistryPullThroughCache(ctx, app.registry, app.driver, config.Proxy)
 		if err != nil {
 			panic(err.Error())
 		}
 		app.isCache = true
 		dcontext.GetLogger(app).Info("Registry configured as a proxy cache to ", config.Proxy.RemoteURL)
+	} else {
+		// Cleanup old Proxy сache data
+		if err := proxy.CleanupCacheStorage(ctx, app.driver); err != nil {
+			panic(fmt.Sprintf("failed to clean up cache storage: %v", err))
+		}
 	}
 	var ok bool
 	app.repoRemover, ok = app.registry.(distribution.RepositoryRemover)

--- a/registry/proxy/cleanup.go
+++ b/registry/proxy/cleanup.go
@@ -1,0 +1,69 @@
+package proxy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/docker/distribution/registry/storage/driver"
+)
+
+func CleanupCacheStorage(ctx context.Context, storage driver.StorageDriver) error {
+	exists, err := scheduleStateExists(ctx, storage)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return cleanupStorage(ctx, storage)
+	}
+	return nil
+}
+
+func cleanupNonCacheStorage(ctx context.Context, storage driver.StorageDriver) error {
+	exists, err := scheduleStateExists(ctx, storage)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return cleanupStorage(ctx, storage)
+	}
+	return nil
+}
+
+func cleanupStorage(ctx context.Context, storage driver.StorageDriver) error {
+	if err := pathDelete(ctx, storage, schedulerStateFilePath); err != nil {
+		return err
+	}
+	// registry/storage/paths.go:13
+	if err := pathDelete(ctx, storage, "/docker"); err != nil {
+		return err
+	}
+	return nil
+}
+
+func scheduleStateExists(ctx context.Context, storage driver.StorageDriver) (bool, error) {
+	return pathExists(ctx, storage, schedulerStateFilePath)
+}
+
+func pathExists(ctx context.Context, storage driver.StorageDriver, path string) (bool, error) {
+	_, err := storage.Stat(ctx, path)
+	switch {
+	case err == nil:
+		return true, nil
+	case errors.As(err, &driver.PathNotFoundError{}):
+		return false, nil
+	default:
+		return false, fmt.Errorf("stat %q: %w", path, err)
+	}
+}
+
+func pathDelete(ctx context.Context, storage driver.StorageDriver, path string) error {
+	err := storage.Delete(ctx, path)
+	switch {
+	case err == nil:
+		return nil
+	case errors.As(err, &driver.PathNotFoundError{}):
+		return nil
+	default:
+		return fmt.Errorf("delete %q: %w", path, err)
+	}
+}

--- a/registry/proxy/const.go
+++ b/registry/proxy/const.go
@@ -1,0 +1,10 @@
+package proxy
+
+import (
+	"time"
+)
+
+const (
+	schedulerStateFilePath = "/scheduler-state.json"
+	schedulerDefaultTTL    = 24 * 7 * time.Hour
+)

--- a/registry/proxy/proxyblobstore_test.go
+++ b/registry/proxy/proxyblobstore_test.go
@@ -180,7 +180,7 @@ func makeTestEnv(t *testing.T, localName, remoteName string) *testEnv {
 		blobs: localRepo.Blobs(ctx),
 	}
 
-	s := scheduler.New(ctx, 24*7*time.Hour, localDriver, localRegistry, "/scheduler-state.json")
+	s := scheduler.New(ctx, 24*7*time.Hour, localDriver, "/scheduler-state.json")
 
 	proxyBlobStore := cachedBlobStore{
 		blobStore: blobStore{
@@ -355,7 +355,7 @@ func testProxyStoreServe(t *testing.T, te *testEnv, numClients int) {
 
 				err = te.store.ServeBlob(te.ctx, w, r, remoteBlob.Digest)
 				if err != nil {
-					t.Errorf(err.Error())
+					t.Error(err.Error())
 					return
 				}
 
@@ -400,7 +400,7 @@ func testProxyStoreServe(t *testing.T, te *testEnv, numClients int) {
 
 		err = te.store.ServeBlob(te.ctx, w, r, dr.Digest)
 		if err != nil {
-			t.Fatalf(err.Error())
+			t.Fatal(err.Error())
 		}
 
 		dl := digest.FromBytes(w.Body.Bytes())

--- a/registry/proxy/proxymanifeststore_test.go
+++ b/registry/proxy/proxymanifeststore_test.go
@@ -124,7 +124,7 @@ func newManifestStoreTestEnv(t *testing.T, localName, remoteName, tag string) *m
 
 	manifestDigest, err := populateRepo(ctx, t, truthRepo, remoteName, tag)
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 
 	localRegistry, err := storage.NewRegistry(ctx, inmemory.New(), storage.BlobDescriptorCacheProvider(memory.NewInMemoryBlobDescriptorCacheProvider()), storage.EnableRedirect, storage.DisableDigestResumption, storage.Schema1SigningKey(k), storage.EnableSchema1)
@@ -145,7 +145,7 @@ func newManifestStoreTestEnv(t *testing.T, localName, remoteName, tag string) *m
 		stats:     make(map[string]int),
 	}
 
-	s := scheduler.New(ctx, 24*7*time.Hour, inmemory.New(), localRegistry, "/scheduler-state.json")
+	s := scheduler.New(ctx, 24*7*time.Hour, inmemory.New(), "/scheduler-state.json")
 	return &manifestStoreTestEnv{
 		manifestDigest: manifestDigest,
 		manifests: cachedManifestStore{
@@ -202,7 +202,7 @@ func populateRepo(ctx context.Context, t *testing.T, repository distribution.Rep
 
 	ms, err := repository.Manifests(ctx)
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 	dgst, err := ms.Put(ctx, sm)
 	if err != nil {

--- a/registry/proxy/proxyregistry.go
+++ b/registry/proxy/proxyregistry.go
@@ -71,7 +71,7 @@ func NewRegistryPullThroughCache(ctx context.Context, registry distribution.Name
 	}
 
 	if ttl != nil {
-		s = scheduler.New(ctx, *ttl, driver, registry, "/scheduler-state.json")
+		s = scheduler.New(ctx, *ttl, driver, "/scheduler-state.json")
 
 		v := storage.NewVacuum(ctx, driver)
 		s.OnBlobExpire(func(ref reference.Reference) error {

--- a/registry/proxy/proxyregistry.go
+++ b/registry/proxy/proxyregistry.go
@@ -9,7 +9,6 @@ import (
 	"net/url"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/distribution/reference"
 	"github.com/docker/distribution"
@@ -21,11 +20,6 @@ import (
 	"github.com/docker/distribution/registry/proxy/scheduler"
 	"github.com/docker/distribution/registry/storage"
 	"github.com/docker/distribution/registry/storage/driver"
-)
-
-const (
-	schedulerStateFilePath = "/scheduler-state.json"
-	schedulerDefaultTTL    = 24 * 7 * time.Hour
 )
 
 // proxyingRegistry fetches content from a remote registry and caches it locally

--- a/registry/proxy/proxyregistry.go
+++ b/registry/proxy/proxyregistry.go
@@ -59,13 +59,10 @@ func NewRegistryPullThroughCache(ctx context.Context, registry distribution.Name
 		return nil, err
 	}
 
-	var (
-		s   *scheduler.TTLExpirationScheduler
-		ttl time.Duration
-	)
+	var s *scheduler.TTLExpirationScheduler
 
-	// Default TTL is 7 days
-	if config.TTL <= 0 {
+	ttl := config.TTL
+	if ttl <= 0 {
 		ttl = schedulerDefaultTTL
 	}
 

--- a/registry/proxy/proxyregistry.go
+++ b/registry/proxy/proxyregistry.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -23,7 +24,10 @@ import (
 	"github.com/docker/distribution/registry/storage/driver"
 )
 
-var repositoryTTL = 24 * 7 * time.Hour
+const (
+	schedulerStateFilePath = "/scheduler-state.json"
+	schedulerDefaultTTL    = 24 * 7 * time.Hour
+)
 
 // proxyingRegistry fetches content from a remote registry and caches it locally
 type proxyingRegistry struct {
@@ -55,23 +59,26 @@ func NewRegistryPullThroughCache(ctx context.Context, registry distribution.Name
 		return nil, err
 	}
 
-	var s *scheduler.TTLExpirationScheduler
-	var ttl *time.Duration
+	var (
+		s   *scheduler.TTLExpirationScheduler
+		ttl time.Duration
+	)
 
-	if config.NoCache {
-		ttl = nil
-	} else if config.TTL == nil {
-		// Default TTL is 7 days
-		ttl = &repositoryTTL
-	} else if *config.TTL > 0 {
-		ttl = config.TTL
-	} else {
-		// TTL is disabled, never expire
-		ttl = nil
+	// Default TTL is 7 days
+	if config.TTL <= 0 {
+		ttl = schedulerDefaultTTL
 	}
 
-	if ttl != nil {
-		s = scheduler.New(ctx, *ttl, driver, "/scheduler-state.json")
+	if config.NoCache {
+		if err := cleanupStorage(ctx, driver); err != nil {
+			return nil, fmt.Errorf("failed to clean up storage: %w", err)
+		}
+	} else {
+		if err := cleanupNonCacheStorage(ctx, driver); err != nil {
+			return nil, fmt.Errorf("failed to clean up non-cache storage: %w", err)
+		}
+
+		s = scheduler.New(ctx, ttl, driver, schedulerStateFilePath)
 
 		v := storage.NewVacuum(ctx, driver)
 		s.OnBlobExpire(func(ref reference.Reference) error {
@@ -372,4 +379,47 @@ func (pr *proxiedRepository) Named() reference.Named {
 
 func (pr *proxiedRepository) Tags(ctx context.Context) distribution.TagService {
 	return pr.tags
+}
+
+func CleanupCacheStorage(ctx context.Context, storage driver.StorageDriver) error {
+	exists, err := scheduleStateExists(ctx, storage)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return cleanupStorage(ctx, storage)
+	}
+	return nil
+}
+
+func cleanupNonCacheStorage(ctx context.Context, storage driver.StorageDriver) error {
+	exists, err := scheduleStateExists(ctx, storage)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return cleanupStorage(ctx, storage)
+	}
+	return nil
+}
+
+func scheduleStateExists(ctx context.Context, storage driver.StorageDriver) (bool, error) {
+	_, err := storage.Stat(ctx, schedulerStateFilePath)
+	switch {
+	case err == nil:
+		return true, nil
+	case errors.As(err, &driver.PathNotFoundError{}):
+		return false, nil
+	default:
+		return false, fmt.Errorf("stat %q: %w", schedulerStateFilePath, err)
+	}
+}
+
+func cleanupStorage(ctx context.Context, storage driver.StorageDriver) error {
+	if err := storage.Delete(ctx, "/"); err != nil {
+		if !errors.As(err, &driver.PathNotFoundError{}) {
+			return fmt.Errorf("cleanup storage: %w", err)
+		}
+	}
+	return nil
 }

--- a/registry/proxy/proxyregistry.go
+++ b/registry/proxy/proxyregistry.go
@@ -403,23 +403,41 @@ func cleanupNonCacheStorage(ctx context.Context, storage driver.StorageDriver) e
 	return nil
 }
 
+func cleanupStorage(ctx context.Context, storage driver.StorageDriver) error {
+	if err := pathDelete(ctx, storage, schedulerStateFilePath); err != nil {
+		return err
+	}
+	// registry/storage/paths.go:13
+	if err := pathDelete(ctx, storage, "/docker"); err != nil {
+		return err
+	}
+	return nil
+}
+
 func scheduleStateExists(ctx context.Context, storage driver.StorageDriver) (bool, error) {
-	_, err := storage.Stat(ctx, schedulerStateFilePath)
+	return pathExists(ctx, storage, schedulerStateFilePath)
+}
+
+func pathExists(ctx context.Context, storage driver.StorageDriver, path string) (bool, error) {
+	_, err := storage.Stat(ctx, path)
 	switch {
 	case err == nil:
 		return true, nil
 	case errors.As(err, &driver.PathNotFoundError{}):
 		return false, nil
 	default:
-		return false, fmt.Errorf("stat %q: %w", schedulerStateFilePath, err)
+		return false, fmt.Errorf("stat %q: %w", path, err)
 	}
 }
 
-func cleanupStorage(ctx context.Context, storage driver.StorageDriver) error {
-	if err := storage.Delete(ctx, "/"); err != nil {
-		if !errors.As(err, &driver.PathNotFoundError{}) {
-			return fmt.Errorf("cleanup storage: %w", err)
-		}
+func pathDelete(ctx context.Context, storage driver.StorageDriver, path string) error {
+	err := storage.Delete(ctx, path)
+	switch {
+	case err == nil:
+		return nil
+	case errors.As(err, &driver.PathNotFoundError{}):
+		return nil
+	default:
+		return fmt.Errorf("delete %q: %w", path, err)
 	}
-	return nil
 }

--- a/registry/proxy/proxyregistry.go
+++ b/registry/proxy/proxyregistry.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -376,65 +375,4 @@ func (pr *proxiedRepository) Named() reference.Named {
 
 func (pr *proxiedRepository) Tags(ctx context.Context) distribution.TagService {
 	return pr.tags
-}
-
-func CleanupCacheStorage(ctx context.Context, storage driver.StorageDriver) error {
-	exists, err := scheduleStateExists(ctx, storage)
-	if err != nil {
-		return err
-	}
-	if exists {
-		return cleanupStorage(ctx, storage)
-	}
-	return nil
-}
-
-func cleanupNonCacheStorage(ctx context.Context, storage driver.StorageDriver) error {
-	exists, err := scheduleStateExists(ctx, storage)
-	if err != nil {
-		return err
-	}
-	if !exists {
-		return cleanupStorage(ctx, storage)
-	}
-	return nil
-}
-
-func cleanupStorage(ctx context.Context, storage driver.StorageDriver) error {
-	if err := pathDelete(ctx, storage, schedulerStateFilePath); err != nil {
-		return err
-	}
-	// registry/storage/paths.go:13
-	if err := pathDelete(ctx, storage, "/docker"); err != nil {
-		return err
-	}
-	return nil
-}
-
-func scheduleStateExists(ctx context.Context, storage driver.StorageDriver) (bool, error) {
-	return pathExists(ctx, storage, schedulerStateFilePath)
-}
-
-func pathExists(ctx context.Context, storage driver.StorageDriver, path string) (bool, error) {
-	_, err := storage.Stat(ctx, path)
-	switch {
-	case err == nil:
-		return true, nil
-	case errors.As(err, &driver.PathNotFoundError{}):
-		return false, nil
-	default:
-		return false, fmt.Errorf("stat %q: %w", path, err)
-	}
-}
-
-func pathDelete(ctx context.Context, storage driver.StorageDriver, path string) error {
-	err := storage.Delete(ctx, path)
-	switch {
-	case err == nil:
-		return nil
-	case errors.As(err, &driver.PathNotFoundError{}):
-		return nil
-	default:
-		return fmt.Errorf("delete %q: %w", path, err)
-	}
 }

--- a/registry/proxy/scheduler/scheduler.go
+++ b/registry/proxy/scheduler/scheduler.go
@@ -8,10 +8,8 @@ import (
 	"time"
 
 	"github.com/distribution/reference"
-	"github.com/docker/distribution"
 	dcontext "github.com/docker/distribution/context"
 	"github.com/docker/distribution/registry/storage/driver"
-	"github.com/opencontainers/go-digest"
 )
 
 // onTTLExpiryFunc is called when a repository's TTL expires
@@ -34,11 +32,10 @@ type schedulerEntry struct {
 }
 
 // New returns a new instance of the scheduler
-func New(ctx context.Context, ttl time.Duration, driver driver.StorageDriver, registry distribution.Namespace, path string) *TTLExpirationScheduler {
+func New(ctx context.Context, ttl time.Duration, driver driver.StorageDriver, path string) *TTLExpirationScheduler {
 	return &TTLExpirationScheduler{
 		entries:         make(map[string]*schedulerEntry),
 		ttl:             ttl,
-		registry:        registry,
 		driver:          driver,
 		pathToStateFile: path,
 		ctx:             ctx,
@@ -55,7 +52,6 @@ type TTLExpirationScheduler struct {
 
 	entries map[string]*schedulerEntry
 
-	registry        distribution.Namespace
 	driver          driver.StorageDriver
 	ctx             context.Context
 	ttl             time.Duration
@@ -69,8 +65,6 @@ type TTLExpirationScheduler struct {
 	indexDirty bool
 	saveTimer  *time.Ticker
 	doneChan   chan struct{}
-
-	startFiller bool // Default - false
 }
 
 // OnBlobExpire is called when a scheduled blob's TTL expires
@@ -163,30 +157,6 @@ func (ttles *TTLExpirationScheduler) Start() error {
 		}
 	}()
 
-	if ttles.startFiller {
-		go func() {
-			for {
-				dcontext.GetLogger(ttles.ctx).Infof("Starting cache loading from storage...")
-				err := ttles.fillStateFromStorage()
-				if err != nil {
-					dcontext.GetLogger(ttles.ctx).Errorf("Error loading scheduler state: %s", err)
-					time.Sleep(20 * time.Second)
-				} else {
-					break
-				}
-			}
-
-			ttles.Lock()
-			defer ttles.Unlock()
-			ttles.startFiller = false
-
-			err = ttles.writeState()
-			if err != nil {
-				dcontext.GetLogger(ttles.ctx).Errorf("Error writing scheduler state: %s", err)
-			}
-			dcontext.GetLogger(ttles.ctx).Infof("Cache loading from storage completed successfully.")
-		}()
-	}
 	return nil
 }
 
@@ -256,10 +226,6 @@ func (ttles *TTLExpirationScheduler) Stop() {
 }
 
 func (ttles *TTLExpirationScheduler) writeState() error {
-	if ttles.startFiller {
-		dcontext.GetLogger(ttles.ctx).Warnf("Writing state is not allowed")
-		return nil
-	}
 	jsonBytes, err := json.Marshal(ttles.entries)
 	if err != nil {
 		return err
@@ -269,6 +235,7 @@ func (ttles *TTLExpirationScheduler) writeState() error {
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -276,7 +243,6 @@ func (ttles *TTLExpirationScheduler) readState() error {
 	if _, err := ttles.driver.Stat(ttles.ctx, ttles.pathToStateFile); err != nil {
 		switch err := err.(type) {
 		case driver.PathNotFoundError:
-			ttles.startFiller = true
 			return nil
 		default:
 			return err
@@ -291,118 +257,6 @@ func (ttles *TTLExpirationScheduler) readState() error {
 	err = json.Unmarshal(bytes, &ttles.entries)
 	if err != nil {
 		return err
-	}
-	return nil
-}
-
-// loadStateFromStorage sets expiration (TTL) for manifests and blobs in the repository
-func (ttles *TTLExpirationScheduler) fillStateFromStorage() error {
-	// Convert registry to a RepositoryEnumerator to enable repository iteration
-	repositoryEnumerator, ok := ttles.registry.(distribution.RepositoryEnumerator)
-	if !ok {
-		return fmt.Errorf("unable to convert Namespace to RepositoryEnumerator")
-	}
-
-	// Maps to track manifests and blobs that will have TTLs assigned
-	manifestRefSet := make(map[reference.Canonical]struct{})
-	blobRefMap := make(map[digest.Digest]reference.Canonical)
-
-	// Iterate through all repositories in the registry
-	err := repositoryEnumerator.Enumerate(ttles.ctx, func(repoName string) error {
-		named, err := reference.WithName(repoName)
-		if err != nil {
-			return fmt.Errorf("failed to parse repo name %s: %v", repoName, err)
-		}
-
-		// Get the repository object for the current repoName
-		repository, err := ttles.registry.Repository(ttles.ctx, named)
-		if err != nil {
-			return fmt.Errorf("failed to construct repository: %v", err)
-		}
-
-		// Get the manifest service for this repository
-		manifestService, err := repository.Manifests(ttles.ctx)
-		if err != nil {
-			return fmt.Errorf("failed to construct manifest service: %v", err)
-		}
-
-		// Convert the manifest service to a ManifestEnumerator for manifest iteration
-		manifestEnumerator, ok := manifestService.(distribution.ManifestEnumerator)
-		if !ok {
-			return fmt.Errorf("unable to convert ManifestService into ManifestEnumerator")
-		}
-
-		// Enumerate through all manifests in the repository
-		err = manifestEnumerator.Enumerate(ttles.ctx, func(dgst digest.Digest) error {
-			// Add the manifest reference to the tracking set
-			manifestRef, err := reference.WithDigest(named, dgst)
-			if err != nil {
-				return fmt.Errorf("failed to create manifest reference: %v", err)
-			}
-			manifestRefSet[manifestRef] = struct{}{}
-
-			// Get the manifest data for the given digest
-			manifest, err := manifestService.Get(ttles.ctx, dgst)
-			if err != nil {
-				return fmt.Errorf("failed to retrieve manifest for digest %v: %v", dgst, err)
-			}
-
-			// Add all blobs referenced by the manifest to the blob tracking map
-			descriptors := manifest.References()
-			for _, descriptor := range descriptors {
-				blobDigest := descriptor.Digest
-				blobRef, err := reference.WithDigest(named, descriptor.Digest)
-				if err != nil {
-					return fmt.Errorf("failed to create blob reference: %v", err)
-				}
-				blobRefMap[blobDigest] = blobRef
-			}
-			return nil
-		})
-
-		// Handle non-existent paths such as unfinished uploads or deleted content
-		if err != nil {
-			if _, ok := err.(driver.PathNotFoundError); !ok {
-				return fmt.Errorf("failed to mark manifests: %v", err)
-			}
-		}
-		return nil
-	})
-
-	if err != nil {
-		if _, ok := err.(driver.PathNotFoundError); !ok {
-			return fmt.Errorf("failed to mark repositories: %v", err)
-		}
-	}
-
-	// Map to track blob references
-	blobRefSet := make(map[reference.Canonical]struct{})
-	blobEnumerator := ttles.registry.Blobs()
-
-	// Enumerate through all blobs in the registry
-	err = blobEnumerator.Enumerate(ttles.ctx, func(dgst digest.Digest) error {
-		blobRef, ok := blobRefMap[dgst]
-		if ok {
-			blobRefSet[blobRef] = struct{}{}
-		}
-		return nil
-	})
-	if err != nil {
-		if _, ok := err.(driver.PathNotFoundError); !ok {
-			return fmt.Errorf("failed to mark blobs: %v", err)
-		}
-	}
-
-	ttles.Lock()
-	defer ttles.Unlock()
-	// Schedule TTL for all tracked manifests
-	for manifestRef := range manifestRefSet {
-		ttles.add(manifestRef, entryTypeManifest)
-	}
-
-	// Schedule TTL for all tracked blobs
-	for blobRef := range blobRefSet {
-		ttles.add(blobRef, entryTypeBlob)
 	}
 	return nil
 }

--- a/registry/proxy/scheduler/scheduler.go
+++ b/registry/proxy/scheduler/scheduler.go
@@ -114,7 +114,7 @@ func (ttles *TTLExpirationScheduler) Start() error {
 	ttles.Lock()
 	defer ttles.Unlock()
 
-	err := ttles.readState()
+	err := ttles.initState()
 	if err != nil {
 		return err
 	}
@@ -239,11 +239,11 @@ func (ttles *TTLExpirationScheduler) writeState() error {
 	return nil
 }
 
-func (ttles *TTLExpirationScheduler) readState() error {
+func (ttles *TTLExpirationScheduler) initState() error {
 	if _, err := ttles.driver.Stat(ttles.ctx, ttles.pathToStateFile); err != nil {
 		switch err := err.(type) {
 		case driver.PathNotFoundError:
-			return nil
+			return ttles.writeState()
 		default:
 			return err
 		}

--- a/registry/proxy/scheduler/scheduler_test.go
+++ b/registry/proxy/scheduler/scheduler_test.go
@@ -30,6 +30,24 @@ func testRefs(t *testing.T) (reference.Reference, reference.Reference, reference
 	return ref1, ref2, ref3
 }
 
+func TestInitState(t *testing.T) {
+	ttl := 10 * time.Millisecond
+	storage := inmemory.New()
+	stateFilePath := "/ttl"
+
+	ctx := t.Context()
+	s := New(ctx, ttl, storage, stateFilePath)
+
+	err := s.Start()
+	if err != nil {
+		t.Fatalf("failed to start scheduler: %v", err)
+	}
+
+	if _, err := storage.Stat(ctx, stateFilePath); err != nil {
+		t.Fatalf("expected state file %q to exist in storage: %v", stateFilePath, err)
+	}
+}
+
 func TestSchedule(t *testing.T) {
 	fs := inmemory.New()
 	timeUnit := time.Millisecond

--- a/registry/proxy/scheduler/scheduler_test.go
+++ b/registry/proxy/scheduler/scheduler_test.go
@@ -1,137 +1,15 @@
 package scheduler
 
 import (
-	"context"
 	"encoding/json"
-	"fmt"
-	"io"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/distribution/reference"
-	"github.com/docker/distribution"
-	distribution_context "github.com/docker/distribution/context"
-	"github.com/docker/distribution/manifest"
-	"github.com/docker/distribution/manifest/schema1"
-	"github.com/docker/distribution/registry/storage"
-	"github.com/docker/distribution/registry/storage/cache/memory"
-	storagedriver "github.com/docker/distribution/registry/storage/driver"
+	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/registry/storage/driver/inmemory"
-	"github.com/docker/distribution/testutil"
-	"github.com/docker/libtrust"
 )
-
-type schedulerEntryTest struct {
-	EntryType int `json:"EntryType"`
-}
-
-func newRegistry(t *testing.T) (storagedriver.StorageDriver, distribution.Namespace) {
-	ctx := distribution_context.Background()
-	k, err := libtrust.GenerateECP256PrivateKey()
-	if err != nil {
-		t.Fatal(err)
-	}
-	localDriver := inmemory.New()
-	localRegistry, err := storage.NewRegistry(ctx, localDriver, storage.BlobDescriptorCacheProvider(memory.NewInMemoryBlobDescriptorCacheProvider()), storage.EnableRedirect, storage.DisableDigestResumption, storage.Schema1SigningKey(k), storage.EnableSchema1)
-	if err != nil {
-		t.Fatalf("error creating registry: %v", err)
-	}
-	return localDriver, localRegistry
-}
-
-func populateRepo(ctx context.Context, t *testing.T, registry distribution.Namespace, repoName, tag string, blobsCount int) (reference.Canonical, []reference.Canonical) {
-	blobsRefs := make([]reference.Canonical, 0, blobsCount)
-
-	// Manifest that will contain information about the layers (blobs)
-	m := schema1.Manifest{
-		Versioned: manifest.Versioned{
-			SchemaVersion: 1,
-		},
-		Name: repoName,
-		Tag:  tag,
-	}
-
-	// Parse repository name reference
-	repoRef, err := reference.WithName(repoName)
-	if err != nil {
-		t.Fatalf("unable to parse reference for repository name %s: %v", repoName, err)
-	}
-
-	// Get the repository from the namespace
-	repository, err := registry.Repository(ctx, repoRef)
-	if err != nil {
-		t.Fatalf("unexpected error getting repository '%s': %v", repoName, err)
-	}
-
-	// Create blobs and add them to the manifest
-	for i := 0; i < blobsCount; i++ {
-		wr, err := repository.Blobs(ctx).Create(ctx)
-		if err != nil {
-			t.Fatalf("unexpected error creating test upload for blob %d: %v", i, err)
-		}
-
-		// Generate a random tar file
-		rs, blobDgst, err := testutil.CreateRandomTarFile()
-		if err != nil {
-			t.Fatalf("unexpected error generating test layer file for blob %d: %v", i, err)
-		}
-
-		// Copy data into the blob
-		if _, err := io.Copy(wr, rs); err != nil {
-			t.Fatalf("unexpected error copying to upload for blob %d: %v", i, err)
-		}
-
-		// Commit the blob
-		if _, err := wr.Commit(ctx, distribution.Descriptor{Digest: blobDgst}); err != nil {
-			t.Fatalf("unexpected error committing upload for blob %d: %v", i, err)
-		}
-
-		// Create a reference for the blob
-		blobRef, err := reference.WithDigest(repoRef, blobDgst)
-		if err != nil {
-			t.Fatalf("failed to create blob reference for blob %d: %v", i, err)
-		}
-
-		blobsRefs = append(blobsRefs, blobRef)
-
-		// Add blob information to the manifest
-		m.FSLayers = append(m.FSLayers, schema1.FSLayer{BlobSum: blobDgst})
-		m.History = append(m.History, schema1.History{V1Compatibility: fmt.Sprintf(`{"id": "%d"}`, i)})
-	}
-
-	// Generate a private key for signing the manifest
-	pk, err := libtrust.GenerateECP256PrivateKey()
-	if err != nil {
-		t.Fatalf("unexpected error generating private key: %v", err)
-	}
-
-	// Sign the manifest
-	sm, err := schema1.Sign(&m, pk)
-	if err != nil {
-		t.Fatalf("error signing manifest: %v", err)
-	}
-
-	// Get the manifest service from the repository
-	ms, err := repository.Manifests(ctx)
-	if err != nil {
-		t.Fatalf("error retrieving manifests from repository: %v", err)
-	}
-
-	// Store the manifest in the repository
-	manifestDgst, err := ms.Put(ctx, sm)
-	if err != nil {
-		t.Fatalf("unexpected error putting manifest: %v", err)
-	}
-
-	// Create a reference for the manifest
-	manifestRef, err := reference.WithDigest(repoRef, manifestDgst)
-	if err != nil {
-		t.Fatalf("failed to create manifest reference: %v", err)
-	}
-
-	return manifestRef, blobsRefs
-}
 
 func testRefs(t *testing.T) (reference.Reference, reference.Reference, reference.Reference) {
 	ref1, err := reference.Parse("testrepo@sha256:aaaaeaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
@@ -153,7 +31,7 @@ func testRefs(t *testing.T) (reference.Reference, reference.Reference, reference
 }
 
 func TestSchedule(t *testing.T) {
-	driver, registry := newRegistry(t)
+	fs := inmemory.New()
 	timeUnit := time.Millisecond
 	ttl := 10 * timeUnit
 
@@ -165,7 +43,7 @@ func TestSchedule(t *testing.T) {
 	}
 
 	var mu sync.Mutex
-	s := New(context.Background(), ttl, driver, registry, "/ttl")
+	s := New(context.Background(), ttl, fs, "/ttl")
 	deleteFunc := func(repoName reference.Reference) error {
 		if len(remainingRepos) == 0 {
 			t.Fatalf("Incorrect expiry count")
@@ -208,7 +86,7 @@ func TestSchedule(t *testing.T) {
 }
 
 func TestRestoreOld(t *testing.T) {
-	driver, registry := newRegistry(t)
+	fs := inmemory.New()
 	ttl := 24 * 7 * time.Hour
 
 	ref1, ref2, _ := testRefs(t)
@@ -254,11 +132,12 @@ func TestRestoreOld(t *testing.T) {
 
 	ctx := context.Background()
 	pathToStatFile := "/ttl"
-	err = driver.PutContent(ctx, pathToStatFile, serialized)
+
+	err = fs.PutContent(ctx, pathToStatFile, serialized)
 	if err != nil {
 		t.Fatal("Unable to write serialized data to fs")
 	}
-	s := New(context.Background(), ttl, driver, registry, "/ttl")
+	s := New(context.Background(), ttl, fs, pathToStatFile)
 	s.OnBlobExpire(deleteFunc)
 	err = s.Start()
 	if err != nil {
@@ -275,7 +154,7 @@ func TestRestoreOld(t *testing.T) {
 
 	// Check state file, it should be empty
 	<-time.After(5 * time.Second)
-	content, err := driver.GetContent(ctx, pathToStatFile)
+	content, err := fs.GetContent(ctx, pathToStatFile)
 	if err != nil {
 		t.Fatal("Unable to get data from fs")
 	}
@@ -289,141 +168,8 @@ func TestRestoreOld(t *testing.T) {
 	}
 }
 
-func TestStoreState(t *testing.T) {
-	pathToStatFile := "/ttl"
-	timeUnit := time.Second
-
-	ctx := context.Background()
-	driver, registry := newRegistry(t)
-	v := storage.NewVacuum(ctx, driver)
-	ttl := 24 * 7 * time.Hour
-
-	// Create img1, img2, img3
-	manifestRef1, blobsRef1 := populateRepo(ctx, t, registry, "test", "latest", 1)
-	manifestRef2, blobsRef2 := populateRepo(ctx, t, registry, "a/b/c", "latest", 3)
-	manifestRef3, blobsRef3 := populateRepo(ctx, t, registry, "c/d/e", "latest", 6)
-
-	onBlobExpire := func(ref reference.Reference) error {
-		var r reference.Canonical
-		var ok bool
-		if r, ok = ref.(reference.Canonical); !ok {
-			return fmt.Errorf("unexpected reference type : %T", ref)
-		}
-
-		repo, err := registry.Repository(ctx, r)
-		if err != nil {
-			return err
-		}
-
-		blobs := repo.Blobs(ctx)
-
-		err = blobs.Delete(ctx, r.Digest())
-		if err != nil {
-			return err
-		}
-
-		err = v.RemoveBlob(r.Digest().String())
-		if err != nil {
-			return err
-		}
-
-		return nil
-	}
-
-	onManifestExpire := func(ref reference.Reference) error {
-		var r reference.Canonical
-		var ok bool
-		if r, ok = ref.(reference.Canonical); !ok {
-			return fmt.Errorf("unexpected reference type : %T", ref)
-		}
-
-		repo, err := registry.Repository(ctx, r)
-		if err != nil {
-			return err
-		}
-
-		manifests, err := repo.Manifests(ctx)
-		if err != nil {
-			return err
-		}
-		err = manifests.Delete(ctx, r.Digest())
-		if err != nil {
-			return err
-		}
-		return nil
-	}
-
-	// Create default state with img1 and img2 (Expiry after 1 seconds)
-	schedulerEntries := map[string]*schedulerEntry{}
-	for _, manifest := range []reference.Canonical{manifestRef1, manifestRef2} {
-		schedulerEntries[manifest.String()] = &schedulerEntry{
-			Expiry:    time.Now().Add(1 * timeUnit),
-			Key:       manifest.String(),
-			EntryType: entryTypeManifest,
-		}
-	}
-	for _, blob := range append(blobsRef1, blobsRef2...) {
-		schedulerEntries[blob.String()] = &schedulerEntry{
-			Expiry:    time.Now().Add(1 * timeUnit),
-			Key:       blob.String(),
-			EntryType: entryTypeBlob,
-		}
-	}
-	serialized, err := json.Marshal(&schedulerEntries)
-	if err != nil {
-		t.Fatalf("Error serializing test data: %s", err.Error())
-	}
-	err = driver.PutContent(ctx, pathToStatFile, serialized)
-	if err != nil {
-		t.Fatal("Unable to write serialized data to fs")
-	}
-
-	// Start sheduler
-	s := New(context.Background(), ttl, driver, registry, pathToStatFile)
-	s.OnBlobExpire(onBlobExpire)
-	s.OnManifestExpire(onManifestExpire)
-	err = s.Start()
-	if err != nil {
-		t.Fatalf("Unable to start scheduler: %v", err)
-	}
-
-	// Add img3 (Expiry after repositoryTTL time)
-	s.AddManifest(manifestRef3)
-	for _, blob := range blobsRef3 {
-		s.AddBlob(blob)
-	}
-
-	// Wait Expiry img1 and img2, and save state file in storage
-	<-time.After(5 * timeUnit)
-	s.Stop()
-
-	// Read the state file content after the first scheduler stop
-	content, err := driver.GetContent(ctx, pathToStatFile)
-	if err != nil {
-		t.Fatalf("Error reading state file after first scheduler stop: %v", err)
-	}
-
-	// Expected only img3 in state file
-	var serializedContent map[string]*schedulerEntryTest
-	if err = json.Unmarshal(content, &serializedContent); err != nil {
-		t.Fatalf("Error unmarshaling content: %s", err)
-	}
-	if len(serializedContent) == 0 {
-		t.Fatalf("Repositories remaining: %#v", serializedContent)
-	}
-
-	expecterContent := map[string]*schedulerEntryTest{}
-	for _, manifest := range []reference.Canonical{manifestRef3} {
-		expecterContent[manifest.String()] = &schedulerEntryTest{EntryType: entryTypeManifest}
-	}
-	for _, blob := range blobsRef3 {
-		expecterContent[blob.String()] = &schedulerEntryTest{EntryType: entryTypeBlob}
-	}
-	compareSchedulerEntryTests(t, serializedContent, expecterContent)
-}
-
 func TestStopRestore(t *testing.T) {
-	driver, registry := newRegistry(t)
+	fs := inmemory.New()
 	timeUnit := time.Millisecond
 	ttl := 100 * timeUnit
 
@@ -442,7 +188,7 @@ func TestStopRestore(t *testing.T) {
 	}
 
 	pathToStateFile := "/ttl"
-	s := New(context.Background(), ttl, driver, registry, pathToStateFile)
+	s := New(context.Background(), ttl, fs, pathToStateFile)
 	s.onBlobExpire = deleteFunc
 
 	err := s.Start()
@@ -458,7 +204,7 @@ func TestStopRestore(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 
 	// v2 will restore state from fs
-	s2 := New(context.Background(), ttl, driver, registry, pathToStateFile)
+	s2 := New(context.Background(), ttl, fs, pathToStateFile)
 	s2.onBlobExpire = deleteFunc
 	err = s2.Start()
 	if err != nil {
@@ -474,345 +220,11 @@ func TestStopRestore(t *testing.T) {
 
 }
 
-func TestFillStateFromStorageExpireState(t *testing.T) {
-	var mu sync.Mutex
-	timeUnit := time.Millisecond
-	pathToStatFile := "/ttl"
-	ttl := 10 * timeUnit
-
-	allManifests := map[reference.Canonical]struct{}{}
-	allBlobs := map[reference.Canonical]struct{}{}
-
-	ctx := context.Background()
-	driver, registry := newRegistry(t)
-
-	// Create img1, img2, img3
-	manifest1, blobs1 := populateRepo(ctx, t, registry, "test", "latest", 1)
-	manifest2, blobs2 := populateRepo(ctx, t, registry, "a/b/c", "latest", 3)
-	manifest3, blobs3 := populateRepo(ctx, t, registry, "c/d/e", "latest", 6)
-
-	allManifests[manifest1] = struct{}{}
-	allManifests[manifest2] = struct{}{}
-	allManifests[manifest3] = struct{}{}
-	for _, blob := range blobs1 {
-		allBlobs[blob] = struct{}{}
-	}
-	for _, blob := range blobs2 {
-		allBlobs[blob] = struct{}{}
-	}
-	for _, blob := range blobs3 {
-		allBlobs[blob] = struct{}{}
-	}
-
-	onBlobExpire := func(ref reference.Reference) error {
-		t.Log("removing blob", ref.String())
-		if len(allBlobs) == 0 {
-			t.Fatalf("Incorrect expiry count")
-		}
-		var r reference.Canonical
-		var ok bool
-		if r, ok = ref.(reference.Canonical); !ok {
-			t.Fatalf("unexpected reference type: %T", ref)
-		}
-		_, ok = allBlobs[r]
-		if !ok {
-			t.Fatalf("Trying to remove nonexistent blob: %s", r.String())
-		}
-		mu.Lock()
-		delete(allBlobs, r)
-		mu.Unlock()
-		return nil
-	}
-	onManifestExpire := func(ref reference.Reference) error {
-		t.Log("removing manifest", ref.String())
-		if len(allManifests) == 0 {
-			t.Fatalf("Incorrect expiry count")
-		}
-		var r reference.Canonical
-		var ok bool
-		if r, ok = ref.(reference.Canonical); !ok {
-			t.Fatalf("unexpected reference type: %T", ref)
-		}
-		_, ok = allManifests[r]
-		if !ok {
-			t.Fatalf("Trying to remove nonexistent manifests: %s", r.String())
-		}
-		mu.Lock()
-		delete(allManifests, r)
-		mu.Unlock()
-		return nil
-	}
-
-	// Start sheduler with empty state, expected startFiller
-	s := New(context.Background(), ttl, driver, registry, pathToStatFile)
-	s.OnBlobExpire(onBlobExpire)
-	s.OnManifestExpire(onManifestExpire)
-	err := s.Start()
-	if err != nil {
-		t.Fatalf("Unable to start scheduler: %v", err)
-	}
-	defer s.Stop()
-
-	<-time.After(500 * timeUnit)
-
-	mu.Lock()
-	defer mu.Unlock()
-
-	// Expected empty blobs and manifests lists
-	if len(allBlobs) != 0 {
-		t.Fatalf("Blobs remaining: %#v", len(allBlobs))
-	}
-	if len(allManifests) != 0 {
-		t.Fatalf("Manifests remaining: %#v", len(allManifests))
-	}
-}
-
-func TestFillStateFromStorageStoreState(t *testing.T) {
-	pathToStatFile := "/ttl"
-	ttl := 10000 * time.Hour
-
-	ctx := context.Background()
-	driver, registry := newRegistry(t)
-	v := storage.NewVacuum(ctx, driver)
-
-	// Create img1, img2, img3
-	manifestRef1, blobsRef1 := populateRepo(ctx, t, registry, "test", "latest", 1)
-	manifestRef2, blobsRef2 := populateRepo(ctx, t, registry, "a/b/c", "latest", 3)
-	manifestRef3, blobsRef3 := populateRepo(ctx, t, registry, "c/d/e", "latest", 6)
-
-	// Create the first scheduler
-	onBlobExpire := func(ref reference.Reference) error {
-		var r reference.Canonical
-		var ok bool
-		if r, ok = ref.(reference.Canonical); !ok {
-			return fmt.Errorf("unexpected reference type : %T", ref)
-		}
-
-		repo, err := registry.Repository(ctx, r)
-		if err != nil {
-			return err
-		}
-
-		blobs := repo.Blobs(ctx)
-
-		// Clear the repository reference and descriptor caches
-		err = blobs.Delete(ctx, r.Digest())
-		if err != nil {
-			return err
-		}
-
-		err = v.RemoveBlob(r.Digest().String())
-		if err != nil {
-			return err
-		}
-
-		return nil
-	}
-
-	onManifestExpire := func(ref reference.Reference) error {
-		var r reference.Canonical
-		var ok bool
-		if r, ok = ref.(reference.Canonical); !ok {
-			return fmt.Errorf("unexpected reference type : %T", ref)
-		}
-
-		repo, err := registry.Repository(ctx, r)
-		if err != nil {
-			return err
-		}
-
-		manifests, err := repo.Manifests(ctx)
-		if err != nil {
-			return err
-		}
-		err = manifests.Delete(ctx, r.Digest())
-		if err != nil {
-			return err
-		}
-		return nil
-	}
-
-	// Start sheduler with empty state, expected startFiller
-	s := New(context.Background(), ttl, driver, registry, pathToStatFile)
-	s.OnBlobExpire(onBlobExpire)
-	s.OnManifestExpire(onManifestExpire)
-	err := s.Start()
-	if err != nil {
-		t.Fatalf("Unable to start scheduler: %v", err)
-	}
-
-	// Let the scheduler run for a while
-	<-time.After(1 * time.Second)
-	s.Stop()
-
-	// Read the state file content after the first scheduler stop
-	// Expected state with img1, img2, img3 manifests and blobs
-	content, err := driver.GetContent(ctx, pathToStatFile)
-	if err != nil {
-		t.Fatalf("Error reading state file after first scheduler stop: %v", err)
-	}
-
-	var serializedContent map[string]*schedulerEntryTest
-	if err = json.Unmarshal(content, &serializedContent); err != nil {
-		t.Fatalf("Error unmarshaling content: %s", err)
-	}
-	if len(serializedContent) == 0 {
-		t.Fatalf("Repositories remaining: %#v", serializedContent)
-	}
-
-	expecterContent := map[string]*schedulerEntryTest{}
-	for _, manifest := range []reference.Canonical{manifestRef1, manifestRef2, manifestRef3} {
-		expecterContent[manifest.String()] = &schedulerEntryTest{EntryType: entryTypeManifest}
-	}
-	for _, blob := range append(blobsRef1, append(blobsRef2, blobsRef3...)...) {
-		expecterContent[blob.String()] = &schedulerEntryTest{EntryType: entryTypeBlob}
-	}
-	compareSchedulerEntryTests(t, serializedContent, expecterContent)
-}
-
-func TestFillStateFromStorageStoreAndUpdateState(t *testing.T) {
-	timeUnit := time.Millisecond
-	pathToStatFile := "/ttl"
-	ttl := 10000 * timeUnit
-
-	ctx := context.Background()
-	driver, registry := newRegistry(t)
-	v := storage.NewVacuum(ctx, driver)
-
-	// Create img1, img2, img3
-	_, _ = populateRepo(ctx, t, registry, "test", "latest", 1)
-	_, _ = populateRepo(ctx, t, registry, "a/b/c", "latest", 3)
-	_, _ = populateRepo(ctx, t, registry, "c/d/e", "latest", 6)
-
-	// Create the first scheduler
-	onBlobExpire := func(ref reference.Reference) error {
-		var r reference.Canonical
-		var ok bool
-		if r, ok = ref.(reference.Canonical); !ok {
-			return fmt.Errorf("unexpected reference type : %T", ref)
-		}
-
-		repo, err := registry.Repository(ctx, r)
-		if err != nil {
-			return err
-		}
-
-		blobs := repo.Blobs(ctx)
-
-		// Clear the repository reference and descriptor caches
-		err = blobs.Delete(ctx, r.Digest())
-		if err != nil {
-			return err
-		}
-
-		err = v.RemoveBlob(r.Digest().String())
-		if err != nil {
-			return err
-		}
-
-		return nil
-	}
-
-	onManifestExpire := func(ref reference.Reference) error {
-		var r reference.Canonical
-		var ok bool
-		if r, ok = ref.(reference.Canonical); !ok {
-			return fmt.Errorf("unexpected reference type : %T", ref)
-		}
-
-		repo, err := registry.Repository(ctx, r)
-		if err != nil {
-			return err
-		}
-
-		manifests, err := repo.Manifests(ctx)
-		if err != nil {
-			return err
-		}
-		err = manifests.Delete(ctx, r.Digest())
-		if err != nil {
-			return err
-		}
-		return nil
-	}
-
-	// Start and stop sheduler with empty state, expected startFiller
-	s1 := New(context.Background(), ttl, driver, registry, pathToStatFile)
-	s1.OnBlobExpire(onBlobExpire)
-	s1.OnManifestExpire(onManifestExpire)
-	err := s1.Start()
-	if err != nil {
-		t.Fatalf("Unable to start scheduler: %v", err)
-	}
-	<-time.After(100 * timeUnit)
-	s1.Stop()
-
-	// Read the state file content after the first scheduler stop
-	bytes1, err := driver.GetContent(ctx, pathToStatFile)
-	if err != nil {
-		t.Fatalf("Error reading state file after first scheduler stop: %v", err)
-	}
-
-	// Load a new image (img 4)
-	manifestRef, blobsRef := populateRepo(ctx, t, registry, "f/g/h", "latest", 2)
-
-	// Start and stop sheduler with not empty state, not expected startFiller
-	s2 := New(context.Background(), ttl, driver, registry, pathToStatFile)
-	s2.OnBlobExpire(onBlobExpire)
-	s2.OnManifestExpire(onManifestExpire)
-	err = s2.Start()
-	if err != nil {
-		t.Fatalf("Unable to start second scheduler: %v", err)
-	}
-	<-time.After(100 * timeUnit)
-	s2.Stop()
-
-	// Read the state file content after the second scheduler stop
-	bytes2, err := driver.GetContent(ctx, pathToStatFile)
-	if err != nil {
-		t.Fatalf("Error reading state file after second scheduler stop: %v", err)
-	}
-
-	// Exprected unchange
-	if string(bytes1) != string(bytes2) {
-		t.Errorf("Expected bytes1 and bytes2 to be equal, but they differ.\nbytes1: %s\nbytes2: %s", string(bytes1), string(bytes2))
-	}
-
-	// Create the third scheduler
-	s3 := New(context.Background(), ttl, driver, registry, pathToStatFile)
-	s3.OnBlobExpire(onBlobExpire)
-	s3.OnManifestExpire(onManifestExpire)
-	err = s3.Start()
-	if err != nil {
-		t.Fatalf("Unable to start third scheduler: %v", err)
-	}
-
-	// Add data to the scheduler with new img4
-	s3.AddManifest(manifestRef)
-	for _, blob := range blobsRef {
-		s3.AddBlob(blob)
-	}
-
-	<-time.After(100 * timeUnit)
-	s3.Stop()
-
-	// Read the state file content after data was added to the scheduler
-	bytes3, err := driver.GetContent(ctx, pathToStatFile)
-	if err != nil {
-		t.Fatalf("Error reading state file after third scheduler stop: %v", err)
-	}
-
-	// Exprected changes with img4
-	if string(bytes2) == string(bytes3) {
-		t.Errorf("Expected bytes2 and bytes3 to be different, but they are equal.\nbytes2: %s\nbytes3: %s", string(bytes2), string(bytes3))
-	}
-}
-
 func TestDoubleStart(t *testing.T) {
-	driver, registry := newRegistry(t)
+	fs := inmemory.New()
 	ttl := 24 * 7 * time.Hour
 
-	s := New(context.Background(), ttl, driver, registry, "/ttl")
+	s := New(context.Background(), ttl, fs, "/ttl")
 	err := s.Start()
 	if err != nil {
 		t.Fatalf("Unable to start scheduler")
@@ -820,34 +232,5 @@ func TestDoubleStart(t *testing.T) {
 	err = s.Start()
 	if err == nil {
 		t.Fatalf("Scheduler started twice without error")
-	}
-}
-
-func compareSchedulerEntryTests(t *testing.T, map1, map2 map[string]*schedulerEntryTest) {
-	// Check if lengths of the maps are different
-	if len(map1) != len(map2) {
-		t.Fatalf("Maps are of different lengths: len(map1) = %d, len(map2) = %d", len(map1), len(map2))
-	}
-
-	// Iterate through the first map
-	for key, entry1 := range map1 {
-		entry2, ok := map2[key]
-
-		// Check if key exists in map2
-		if !ok {
-			t.Fatalf("Key %s found in map1 but not in map2", key)
-		}
-
-		// Handle cases where one or both of the entries are nil
-		if entry1 == nil || entry2 == nil {
-			if entry1 != entry2 { // One is nil, the other is not
-				t.Fatalf("Value for key %s is nil in one map but not the other: map1[%s] = %v, map2[%s] = %v", key, key, entry1, key, entry2)
-			}
-		} else {
-			// Compare the fields of sEntry structs
-			if entry1.EntryType != entry2.EntryType {
-				t.Fatalf("Values for key %s differ: map1[%s].EntryType = %d, map2[%s].EntryType = %d", key, key, entry1.EntryType, key, entry2.EntryType)
-			}
-		}
 	}
 }


### PR DESCRIPTION
## What does this change do?

The change ensures that when switching between Local and Proxy modes, any incorrect state left over from the previous mode is removed.

**How it works:**

1. Starting Local mode:
   - Checks the state of the `/scheduler-state.json` file.
   - If the file exists, it means Proxy mode was active previously, and the old data must be deleted.
   - If the file is absent, it means Local mode was active. Nothing needs to be deleted.

2. Starting Proxy mode:
   - Checks the state of the `/scheduler-state.json` file.
   - If the file is absent, it means Local mode was active previously, and the old data must be deleted. After deletion, the scheduler starts and creates the `/scheduler-state.json` file.
   - If the file exists, it means Proxy mode was active. Nothing needs to be deleted.

3. Starting Proxy (NoCache) mode:
   - All data is deleted.
   - The scheduler does not start, `/scheduler-state.json` is not created

## What was tested?

Performed tests:

- [x] Correctness of cleanup logic when switching modes:
  - `local → proxy` (cleanup of all old data; `/scheduler-state.json` is created during scheduler initialization)
  - `local → Proxy (NoCache)` (cleanup of all old data)
  - `proxy → local` (cleanup of all old data)
  - `proxy → Proxy (NoCache)` (cleanup of all old data)
  - `Proxy (NoCache) → local` (since all data is already deleted when starting Proxy (NoCache), there is no data to clean when switching to local)
  - `Proxy (NoCache) → proxy` (since all data is already deleted when starting Proxy (NoCache), there is no data to clean when switching to proxy; `/scheduler-state.json` is created during scheduler initialization)

- [x] State persistence when restarting the container in the same mode:
  - `local` (data remains unchanged)
  - `proxy recreate` (data remains unchanged)
  - `Proxy (NoCache)` (local data is not used; data is deleted again upon creating Proxy (NoCache), if present)

- [x] `Proxy (NoCache)` works without a `/data` mount

- [x] In proxy mode, the `/scheduler-state.json` file is correctly populated

- [x] In proxy mode, TTL-based deletion works correctly